### PR TITLE
grub2-bhyve: Add -c, --cons-dev option to choose terminal

### DIFF
--- a/grub-core/kern/emu/main.c
+++ b/grub-core/kern/emu/main.c
@@ -102,6 +102,7 @@ static struct argp_option options[] = {
   {"verbose",     'v', 0,      0, N_("print verbose messages."), 0},
   {"hold",     'H', N_("SECS"),      OPTION_ARG_OPTIONAL, N_("wait until a debugger will attach"), 0},
 #ifdef BHYVE
+  {"cons-dev", 'c', N_("cons-dev"), 0, N_("a tty(4) device to use for terminal I/O"), 0},
   {"ncons",  'n', 0,            0, N_("disable insertion of console=ttys0"), 0},
   {"memory", 'M', N_("MBYTES"), 0, N_("guest RAM in MB [default=%d]"), 0},
 #endif
@@ -162,6 +163,9 @@ argp_parser (int key, char *arg, struct argp_state *state)
       verbosity++;
       break;
 #ifdef BHYVE
+    case 'c':
+      grub_emu_bhyve_set_console_dev(xstrdup(arg));
+      break;
     case 'n':
       grub_emu_bhyve_unset_cinsert();
       break;

--- a/include/grub/emu/bhyve.h
+++ b/include/grub/emu/bhyve.h
@@ -34,6 +34,7 @@ struct grub_bhyve_info {
 };
 
 int grub_emu_bhyve_init(const char *vmname, grub_uint64_t memsz);
+void grub_emu_bhyve_set_console_dev(const char *dev);
 void grub_emu_bhyve_unset_cinsert(void);
 int  EXPORT_FUNC(grub_emu_bhyve_cinsert) (void);
 void EXPORT_FUNC(grub_emu_bhyve_boot32)(grub_uint32_t bootaddr, 


### PR DESCRIPTION
This enables interactive GRUB menus, etc from users such as libvirt.
