### PR TITLE
make bhyve memory map less odd

### DIFF
--- a/grub-core/kern/emu/bhyve_hostif.c
+++ b/grub-core/kern/emu/bhyve_hostif.c
@@ -155,7 +155,7 @@ grub_emu_bhyve_init(const char *name, grub_uint64_t memsz)
   bhyve_info.segs = bhyve_mm;
 
   bhyve_mm[0].start = 0x0;
-  bhyve_mm[0].end = 640*1024 - 1;		/* 640K */
+  bhyve_mm[0].end = 640*1024;		/* 640K */
   bhyve_mm[0].type = GRUB_MEMORY_AVAILABLE;
 
   bhyve_mm[1].start = 1024*1024;


### PR DESCRIPTION
The previous definition of the low memory range resulted in
`0x0` - `0x9fffe` range in the e820 map.
Some Linux tools do not like memory ranges that are not 1KB aligned.
In particular, kexec tools ignored that range when setting up
a memory map for the kdump kernel.  As a result no low memory at all
was available for that kernel but it requires some.  So, the kdump
kernel panic-ed:
```
Kernel panic - not syncing: Cannot allocate trampoline
```