### PR TITLE
Drop root privileges after initialization to reduce attack surface

### DIFF
--- a/grub-core/kern/emu/main.c
+++ b/grub-core/kern/emu/main.c
@@ -353,6 +353,10 @@ main (int argc, char *argv[])
   grub_hostfs_init ();
 
   grub_emu_post_init ();
+#ifdef BHYVE
+  /* Drop privileges and sandbox. */
+  grub_emu_bhyve_post_init ();
+#endif
 
   /* Make sure that there is a root device.  */
   if (! root_dev)

--- a/include/grub/emu/bhyve.h
+++ b/include/grub/emu/bhyve.h
@@ -43,6 +43,7 @@ struct grub_bhyve_info {
 };
 
 int  grub_emu_bhyve_init(const char *vmname, grub_uint64_t memsz);
+void grub_emu_bhyve_post_init(void);
 int  grub_emu_bhyve_parse_memsize(const char *arg, grub_uint64_t *size);
 void grub_emu_bhyve_set_console_dev(const char *dev);
 void grub_emu_bhyve_unset_cinsert(void);

--- a/include/grub/emu/bhyve.h
+++ b/include/grub/emu/bhyve.h
@@ -58,4 +58,6 @@ void EXPORT_FUNC(grub_emu_bhyve_boot64)(struct grub_relocator64_state rs);
 const struct grub_bhyve_info * EXPORT_FUNC(grub_emu_bhyve_info) (void);
 void * EXPORT_FUNC(grub_emu_bhyve_virt) (grub_uint64_t physaddr);
 
+grub_err_t grub_hostfs_cache_open(const char *name);
+
 #endif /* GRUB_EMU_BHYVE_H */


### PR DESCRIPTION
This is enough to load `device.map` (`main()` → `grub_util_biosdisk_init (arguments.dev_map)`), drop privileges to `nobody:nobody` after initialization, and subsequently load a Linux guest with `linux` and `initrd` commands from an `ext4` disk image.  Hostfs ("`(host)/foo`") access continues to work, as constrained by the Unix permissions of user `nobody`.

I would not be surprised if other functionality were broken by this change.  In particular, anything in grub that writes to disk images specified in `device.map` is broken by this change (only because the files are preopened `O_RDONLY`).  I don't know that this is a particularly important or desirable use case in a Bhyve context.  If it is, it would be trivial to preopen the files as `O_RDWR` instead.

There may be other functionality that tries to access the filesystem after this point.  Some of it may even be a legitimate use; if it is, we can probably preopen it before the privilege boundary.

The key consideration here is that bhyve-grub runs as root, in order to create and allocate the `vmm` device, but also interprets untrusted guest `grub.cfg` input.  Grub was designed to run in a privileged context where `grub.cfg` was trusted, and is not especially hardened to untrusted input.  In grub-bhyve we reuse it in this context, which is somewhat dangerous.  This is a broad and relatively small mitigation that may prevent a class of privilege escalation by malicious or compromised guests.

A next step would be further sandboxing with Capsicum.