### PR TITLE
Update OpenBSD boot arguments for console device.

### DIFF
--- a/grub-core/loader/i386/bsdXX.c
+++ b/grub-core/loader/i386/bsdXX.c
@@ -521,16 +521,66 @@ SUFFIX(grub_openbsd_find_ramdisk) (grub_file_t file,
 				   struct grub_openbsd_ramdisk_descriptor *desc)
 {
   unsigned symoff, stroff, symsize, strsize, symentsize;
+  Elf_Shdr *rodata;
 
   {
     grub_err_t err;
     Elf_Ehdr e;
-    Elf_Shdr *s;
-    char *shdr = NULL;
+    Elf_Shdr *s, *d, *strtab;
+    char *strarr, *shdr = NULL;
     
     err = read_headers (file, filename, &e, &shdr);
     if (err)
       return err;
+
+    for (s = (Elf_Shdr *) shdr;
+	 s < (Elf_Shdr *) (shdr + e.e_shnum * e.e_shentsize);
+	 s = (Elf_Shdr *) ((char *) s + e.e_shentsize))
+      if (s->sh_type == SHT_STRTAB)
+	break;
+    if (s >= (Elf_Shdr *) ((char *) shdr + e.e_shnum * e.e_shentsize))
+      {
+	grub_free (shdr);
+	return GRUB_ERR_NONE;
+      }
+    strtab = s;
+
+    strarr = grub_malloc (strtab->sh_size);
+    if (!strarr)
+      {
+	grub_free (shdr);
+        return grub_errno;
+      }
+
+    if (grub_file_seek (file, strtab->sh_offset) == (grub_off_t) -1)
+      {
+	grub_free (strarr);
+	grub_free (shdr);
+	return grub_errno;
+      }
+    if (grub_file_read (file, strarr, strtab->sh_size) != (grub_ssize_t) strtab->sh_size)
+      {
+        grub_free (strarr);
+        grub_free (shdr);
+        if (! grub_errno)
+          return grub_error (GRUB_ERR_BAD_OS, N_("premature end of file %s"),
+			     filename);
+        return grub_errno;
+      }
+
+    for (s = (Elf_Shdr *) shdr;
+	 s < (Elf_Shdr *) (shdr + e.e_shnum * e.e_shentsize);
+	 s = (Elf_Shdr *) ((char *) s + e.e_shentsize))
+      if (s->sh_type == SHT_PROGBITS &&
+	  grub_strcmp(&strarr[s->sh_name], ".rodata") == 0)
+	break;
+    grub_free (strarr);
+    if (s >= (Elf_Shdr *) ((char *) shdr + e.e_shnum * e.e_shentsize))
+      {
+	grub_free (shdr);
+	return GRUB_ERR_NONE;
+      }
+    rodata = s;
 
     for (s = (Elf_Shdr *) shdr; s < (Elf_Shdr *) (shdr
 						  + e.e_shnum * e.e_shentsize);
@@ -553,7 +603,7 @@ SUFFIX(grub_openbsd_find_ramdisk) (grub_file_t file,
     grub_free (shdr);
   }
   {
-    Elf_Sym *syms, *sym, *imagesym = NULL, *sizesym = NULL;
+    Elf_Sym *syms, *sym, *imagesym = NULL, *sizesym = NULL, *osrelsym = NULL;
     unsigned i;
     char *strs;
 
@@ -605,9 +655,45 @@ SUFFIX(grub_openbsd_find_ramdisk) (grub_file_t file,
 	  imagesym = sym;
 	if (grub_strcmp (strs + sym->st_name, "rd_root_size") == 0)
 	  sizesym = sym;
-	if (imagesym && sizesym)
+	if (grub_strcmp (strs + sym->st_name, "osrelease") == 0)
+	  osrelsym = sym;
+	if (imagesym && sizesym && osrelsym)
 	  break;
       }
+    if (osrelsym) {
+      char *p;
+      int major, minor;
+      grub_size_t sz;
+      char osrel[16];
+      stroff = ((osrelsym->st_value - rodata->sh_addr) + rodata->sh_offset);
+      if (grub_file_seek (file, stroff) == (grub_off_t) -1) {
+	grub_free (syms);
+	grub_free (strs);
+        return grub_errno;
+      }
+      sz = sizeof(osrel) < osrelsym->st_size ? sizeof(osrel) : osrelsym->st_size;
+      if (grub_file_read (file, osrel, sz) != (grub_ssize_t) sz) {
+	grub_free (syms);
+	grub_free (strs);
+        return grub_errno;
+      }
+      osrel[sz - 1] = '\0';
+      major = minor = 0;
+      for (p = osrel; *p != '\0'; p++)
+        if (*p >= '0' && *p <= '9')
+          major = major * 10 + *p - '0';
+        else
+          break;
+      if (*p == '.')
+        p++;
+      for (; *p != '\0'; p++)
+        if (*p >= '0' && *p <= '9')
+           minor = minor * 10 + *p - '0';
+        else
+          break;
+      desc->osrelease = major * 1000 + minor;
+    }
+
     if (!imagesym || !sizesym)
       {
 	grub_free (syms);

--- a/include/grub/i386/bsd.h
+++ b/include/grub/i386/bsd.h
@@ -108,6 +108,7 @@ struct grub_openbsd_ramdisk_descriptor
   grub_size_t max_size;
   grub_uint8_t *target;
   grub_uint32_t *size;
+  grub_uint32_t osrelease;
 };
 
 grub_err_t grub_openbsd_find_ramdisk32 (grub_file_t file,

--- a/include/grub/i386/openbsd_bootarg.h
+++ b/include/grub/i386/openbsd_bootarg.h
@@ -63,6 +63,7 @@
 #define	OPENBSD_BOOTARG_MMAP	0
 #define	OPENBSD_BOOTARG_PCIBIOS 4
 #define	OPENBSD_BOOTARG_CONSOLE 5
+#define	OPENBSD_BOOTARG_CONSOLE_LEGACY 6
 
 struct grub_openbsd_bootargs
 {
@@ -71,12 +72,23 @@ struct grub_openbsd_bootargs
   grub_uint32_t ba_next;
 } __attribute__ ((packed));
 
-struct grub_openbsd_bootarg_console
+struct grub_openbsd_bootarg_console_legacy
 {
   grub_uint32_t device;
   grub_uint32_t speed;
   grub_int32_t  addr;
   grub_uint32_t freq;
+};
+
+struct grub_openbsd_bootarg_console
+{
+  grub_uint32_t device;
+  grub_uint32_t speed;
+  grub_uint64_t addr;
+  grub_int32_t  freq;
+  grub_uint32_t flags;
+  grub_int32_t  reg_width;
+  grub_int32_t  reg_shift;
 };
 
 struct grub_openbsd_bootarg_pcibios

--- a/include/grub/i386/openbsd_reboot.h
+++ b/include/grub/i386/openbsd_reboot.h
@@ -68,7 +68,7 @@
 #define OPENBSD_RB_POWERDOWN	(1 << 12) /* attempt to power down machine */
 #define OPENBSD_RB_SERCONS	(1 << 13) /* use serial console if available */
 #define OPENBSD_RB_USERREQ	(1 << 14) /* boot() called at user request (e.g. ddb) */
-#define OPENBSD_RB_LEGACY	(1 << 15) /* Use legacy serial console structure */
+#define OPENBSD_RB_LEGACY	(1 << 31) /* Use legacy serial console structure */
 
 #define OPENBSD_B_DEVMAGIC	0xa0000000
 #define OPENBSD_B_ADAPTORSHIFT	24

--- a/include/grub/i386/openbsd_reboot.h
+++ b/include/grub/i386/openbsd_reboot.h
@@ -68,6 +68,7 @@
 #define OPENBSD_RB_POWERDOWN	(1 << 12) /* attempt to power down machine */
 #define OPENBSD_RB_SERCONS	(1 << 13) /* use serial console if available */
 #define OPENBSD_RB_USERREQ	(1 << 14) /* boot() called at user request (e.g. ddb) */
+#define OPENBSD_RB_LEGACY	(1 << 15) /* Use legacy serial console structure */
 
 #define OPENBSD_B_DEVMAGIC	0xa0000000
 #define OPENBSD_B_ADAPTORSHIFT	24


### PR DESCRIPTION
OpenBSD has dropped supporing old console device structure by the following commit.

https://github.com/Openbsd/src/commit/745c2f60e98fd1f418c104960a567e120624d705

This commit changes to use new console device structure by default. However if the loading kernel is older than '7.3' release, use the old console device structure for compatibility.

The version number is written in the value of 'osrelease' symbol in the OpenBSD
kernel. All the previous releases contain symbol tables, so no problem. 
If users strip the OpenBSD kernel, reading the version number will fail. I added 'kopenbsd -l'
option to force to use the old console device structure.

Reading symbol tables is already implemented in 'grub_openbsd_find_ramdisk'
function. I added reading the value of 'osrelease' symbol in this function to
share the symbol lookup code. And building console device structure is
implemented in 'grub_cmd_openbsd' function, but it is called earlier than
'grub_openbsd_find_ramdisk' function. So 'grub_cmd_openbsd' function never
knows the version number. I changed to build both the new and old console device
structures in 'grub_cmd_openbsd'. They are added to 'tag' list and
'grub_openbsd_boot' function reads the 'tag' list and build stack frame that is
passed to OpenBSD kernel. I changed the building stack frame code to ignore
unnecessary console device structure checked by the 'osrelease' value.

I also added 'openbsd_force_legacy_console' global variable. It's a flag to
force to use the old console device structure. This flag is set by '-l' option.

I confirmed this patch booted OpenBSD kernel from 6.9 to 7.3 and Current successfully.
And also the installers of OpenBSD 6.9 - 7.3 was booted successfully.