### PR TITLE
Add EXT4_FEATURE_INCOMPAT_CSUM_SEED to EXT2_DRIVER_IGNORED_INCOMPAT

### DIFF
--- a/grub-core/fs/ext2.c
+++ b/grub-core/fs/ext2.c
@@ -101,6 +101,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
 #define EXT4_FEATURE_INCOMPAT_EXTENTS		0x0040 /* Extents used */
 #define EXT4_FEATURE_INCOMPAT_64BIT		0x0080
 #define EXT4_FEATURE_INCOMPAT_FLEX_BG		0x0200
+#define EXT4_FEATURE_INCOMPAT_CSUM_SEED 	0x2000
 
 /* The set of back-incompatible features this driver DOES support. Add (OR)
  * flags here as the related features are implemented into the driver.  */
@@ -115,7 +116,8 @@ GRUB_MOD_LICENSE ("GPLv3+");
  *                 ext3 driver to mount the volume will find the journal and
  *                 replay it, potentially corrupting the metadata written by
  *                 the ext2 drivers. Safe to ignore for this RO driver.  */
-#define EXT2_DRIVER_IGNORED_INCOMPAT ( EXT3_FEATURE_INCOMPAT_RECOVER )
+#define EXT2_DRIVER_IGNORED_INCOMPAT ( EXT3_FEATURE_INCOMPAT_RECOVER \
+				     | EXT4_FEATURE_INCOMPAT_CSUM_SEED )
 
 
 #define EXT3_JOURNAL_MAGIC_NUMBER	0xc03b3998U


### PR DESCRIPTION
After installing alpine-standard-3.20.1-x86_64.iso into a bhyve VM,  grub did not recognize the filesystem and would not boot. This was caused by the filesystem using the metadata_csum_seed feature that was not supported by this version of grub.

This is from the installed alpine (note the "metadata_csum_seed"):
```
# dumpe2fs /dev/vda3 | grep "Filesystem feature"
dumpe2fs 1.47.0 (5-Feb-2023)
Filesystem features:      has_journal ext_attr resize_inode dir_index orphan_file filetype needs_recovery extent 64bit flex_bg metadata_csum_seed sparse_super large_file huge_file dir_nlink extra_isize metadata_csum orphan_present
```

The upstream code has this change here:
https://git.savannah.gnu.org/cgit/grub.git/tree/grub-core/fs/ext2.c#n118

Note: it might make sense to add the other ignored FEATURES (*_MMP and *LARGEDIR) as well.